### PR TITLE
Updated server to run on http and serve the dist.zip file dirrctly on dev mode

### DIFF
--- a/.vscode/getNet.js
+++ b/.vscode/getNet.js
@@ -1,26 +1,26 @@
-const { networkInterfaces } = require('os');
+const { networkInterfaces } = require('os')
 
 module.exports = async (mode = 'dev') => {
-  const ip = getIp();
-  const port = '5500';
-  const src = `https://${ip || '10.0.0'}:${port}`;
-  console.log('Server starting at: ', src);
-  return { ip, port };
-};
+	const ip = getIp()
+	const port = '5500'
+	const src = `http://${ip || '10.0.0'}:${port}`
+	console.log('Server starting at: ', src)
+	return { ip, port }
+}
 
 function getIp() {
-  const nets = networkInterfaces();
-  let ip = '';
+	const nets = networkInterfaces()
+	let ip = ''
 
-  Object.keys(nets).some((name) => {
-    return nets[name].find((net) => {
-      const familyV4Value = typeof net.family === 'string' ? 'IPv4' : 4;
-      if (net.family === familyV4Value && !net.internal) {
-        ip = net.address;
-        return ip;
-      }
-    });
-  });
+	Object.keys(nets).some(name => {
+		return nets[name].find(net => {
+			const familyV4Value = typeof net.family === 'string' ? 'IPv4' : 4
+			if (net.family === familyV4Value && !net.internal) {
+				ip = net.address
+				return ip
+			}
+		})
+	})
 
-  return ip;
+	return ip
 }

--- a/.vscode/start-server.js
+++ b/.vscode/start-server.js
@@ -1,67 +1,69 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const fs = require('fs');
-const path = require('path');
-const liveServer = require('live-server');
-const getNet = require('./getNet');
+const fs = require('fs')
+const path = require('path')
+const liveServer = require('live-server')
+const getNet = require('./getNet')
 
-const serverCrt = path.resolve(__dirname, 'server.crt');
-const serverKey = path.resolve(__dirname, 'server.key');
+const serverCrt = path.resolve(__dirname, 'server.crt')
+const serverKey = path.resolve(__dirname, 'server.key')
 
-main();
+main()
 
 async function main() {
-  const { ip: host, port } = await getNet('dev');
-  process.cwd = () => __dirname;
-  liveServer.start({
-    open: false,
-    port,
-    host,
-    cors: true,
-    root: '../',
-    ignore: 'node_modules,platforms,plugins',
-    file: 'index.html',
-    https: {
-      cert: fs.readFileSync(serverCrt),
-      key: fs.readFileSync(serverKey),
-      passphrase: '1234',
-    },
-    middleware: [(req, res, next) => {
-      const url = req.originalUrl;
-      const www = '../platforms/android/app/src/main/assets/www/';
+	const { ip: host, port } = await getNet('dev')
+	process.cwd = () => __dirname
+	liveServer.start({
+		open: false,
+		port,
+		host,
+		cors: true,
+		root: '../',
+		ignore: 'node_modules,platforms,plugins',
+		file: 'dist.zip',
+		https: {
+			cert: fs.readFileSync(serverCrt),
+			key: fs.readFileSync(serverKey),
+			passphrase: '1234'
+		},
+		middleware: [
+			(req, res, next) => {
+				const url = req.originalUrl
+				const www = '../platforms/android/app/src/main/assets/www/'
 
-      if (url === '/cordova.js') {
-        const file = path.resolve(__dirname, www, 'cordova.js');
-        sendFile(res, file);
-        return;
-      }
+				if (url === '/cordova.js') {
+					const file = path.resolve(__dirname, www, 'cordova.js')
+					sendFile(res, file)
+					return
+				}
 
-      if (url === '/cordova_plugins.js') {
-        const file = path.resolve(__dirname, www, 'cordova_plugins.js');
-        sendFile(res, file);
-        return;
-      }
+				if (url === '/cordova_plugins.js') {
+					const file = path.resolve(__dirname, www, 'cordova_plugins.js')
+					sendFile(res, file)
+					return
+				}
 
-      next();
-    }],
-  });
+				next()
+			}
+		]
+	})
 
-  process.send('OK');
+	process.send('OK')
 }
 
 function sendFile(res, filePath) {
-  if (fs.existsSync(filePath)) {
-    const stat = fs.statSync(filePath);
+	if (fs.existsSync(filePath)) {
+		const stat = fs.statSync(filePath)
 
-    res.writeHead(200, {
-      'Content-Type': 'application/javascript',
-      'Content-Length': stat.size,
-    });
+		res.writeHead(200, {
+			'Content-Type': 'application/javascript',
+			'Content-Length': stat.size
+		})
 
-    const readStream = fs.createReadStream(filePath);
-    readStream.pipe(res);
-    return;
-  }
+		const readStream = fs.createReadStream(filePath)
+		readStream.pipe(res)
+		return
+	}
 
-  res.writeHead(404, { 'Content-Type': 'text/plain' });
-  res.end(`ERROR cannot get ${filePath}`);
+	res.writeHead(404, { 'Content-Type': 'text/plain' })
+	res.end(`ERROR cannot get ${filePath}`)
 }


### PR DESCRIPTION
I worked on the server, because when running the dev command `npm run start-dev` it complains of SSL certificate length is too small, so I have to run make it HTTP instead of HTTPS and is working fine, didn't remove the SSL though.

Also after it's been debugged, we'll have to start specifying `http://10.229.145.76:5500/dist.zip` which is not the default value in the remote url when tying to add local extension, so i have to make the default `/` initial url to show the dist.zip

Note: Those comma that are removed are with formatter extension on Acode.