### PR TITLE
fix: update broken documentation link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Acode plugin
 
-Read acode plugin [documentation](https://acode.app/plugin-docs) to develop plugin for acode editor.
+Read acode plugin [documentation](https://docs.acode.app/docs/) to develop plugin for acode editor.
 
 ## Usage
 


### PR DESCRIPTION
Replaced the outdated or broken link to the documentation with the correct one. Ensures users can access the relevant resources without issues.

from https://acode.app/plugin-docs  --> https://docs.acode.app/docs/